### PR TITLE
Add owner notifications and startup self-test

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -16,6 +16,19 @@ async def __on_start_up(dp: Dispatcher) -> None:
     register_all_handlers(dp)
     register_models()
 
+    try:
+        owner_id = int(EnvKeys.OWNER_ID) if EnvKeys.OWNER_ID else None
+    except (TypeError, ValueError):
+        owner_id = None
+
+    if owner_id:
+        try:
+            await dp.bot.send_message(owner_id, "✅ Bot started and ready to send purchase notifications.")
+        except Exception as e:
+            logger.error("Startup ping to OWNER_ID=%s failed: %s", owner_id, e)
+    else:
+        logger.warning("OWNER_ID is not set or invalid; cannot send startup ping.")
+
 
 def start_bot():
     bot = Bot(token=EnvKeys.TOKEN, parse_mode='HTML')

--- a/bot/utils/notifications.py
+++ b/bot/utils/notifications.py
@@ -1,7 +1,11 @@
 import os
 from aiogram import Bot
-
+from aiogram.utils.exceptions import (
+    ChatNotFound, BotBlocked, CantInitiateConversation,
+    WrongFileIdentifier, TelegramAPIError
+)
 from bot.misc import EnvKeys
+from bot.logger_mesh import logger
 
 
 async def notify_owner_of_purchase(
@@ -14,44 +18,55 @@ async def notify_owner_of_purchase(
     category_name: str,
     photo_description: str,
     file_path: str | None,
-) -> None:
-    """Send purchase details to the bot owner.
-
-    If ``file_path`` is provided and points to an existing file, the file is sent
-    as a photo/video with the details in the caption. Otherwise a text message is
-    sent.
-
-    The notification includes the buyer's username, purchase date, product name,
-    price, category, subcategory and photo description.
+):
     """
-    text = (
-        f"User: {username}\n"
-        f"Date: {formatted_time} GMT+3\n"
-        f"Product: {item_name}\n"
-        f"Price: {item_price}€\n"
-        f"Category: {parent_cat or '-'}\n"
-        f"Subcategory: {category_name}\n"
-        f"Photo description: {photo_description or '-'}"
-    )
-
-    owner_id = EnvKeys.OWNER_ID
-    if not owner_id:
-        return
+    Send a purchase notification to the OWNER_ID with details.
+    If a media file path is provided and exists, send photo/video + caption,
+    otherwise send a text message. All sends are protected with try/except.
+    """
+    # 1) Resolve & validate OWNER_ID
     try:
-        owner_id = int(owner_id)
+        owner_id = int(EnvKeys.OWNER_ID) if EnvKeys.OWNER_ID else None
     except (TypeError, ValueError):
-        pass
+        owner_id = None
 
-    owner_id = int(EnvKeys.OWNER_ID) if EnvKeys.OWNER_ID else None
-    if owner_id is None:
+    if not owner_id:
+        logger.warning("notify_owner_of_purchase: OWNER_ID is missing or invalid.")
         return
 
+    # 2) Build caption (HTML)
+    prefix = f"{parent_cat} → " if parent_cat else ""
+    text = (
+        f"🛒 <b>New purchase</b>\n"
+        f"👤 Buyer: {username}\n"
+        f"🗓️ Time: {formatted_time}\n"
+        f"📦 Item: {prefix}{category_name} / <b>{item_name}</b>\n"
+        f"💶 Price: <b>{item_price}€</b>\n"
+        f"\n{photo_description or ''}"
+    ).strip()
 
-    if file_path and os.path.isfile(file_path):
-        with open(file_path, "rb") as media:
-            if file_path.endswith(".mp4"):
-                await bot.send_video(owner_id, media, caption=text)
-            else:
-                await bot.send_photo(owner_id, media, caption=text)
-    else:
-        await bot.send_message(owner_id, text)
+    # 3) Try media first if available, else text; fall back to plain text on errors
+    try:
+        if file_path and os.path.isfile(file_path):
+            with open(file_path, "rb") as media:
+                if file_path.lower().endswith(".mp4"):
+                    await bot.send_video(owner_id, media, caption=text, parse_mode="HTML")
+                else:
+                    await bot.send_photo(owner_id, media, caption=text, parse_mode="HTML")
+        else:
+            await bot.send_message(owner_id, text, parse_mode="HTML")
+
+    except (BotBlocked, CantInitiateConversation):
+        logger.error(
+            "notify_owner_of_purchase: Cannot DM OWNER_ID=%s (bot blocked or no conversation). "
+            "Ask the owner to /start the bot once.", owner_id
+        )
+    except (ChatNotFound, WrongFileIdentifier) as e:
+        logger.exception("notify_owner_of_purchase: Chat/file issue: %s", e)
+        try:
+            await bot.send_message(owner_id, text, parse_mode="HTML")
+        except TelegramAPIError as e2:
+            logger.exception("notify_owner_of_purchase: Fallback send_message failed: %s", e2)
+    except TelegramAPIError as e:
+        logger.exception("notify_owner_of_purchase: Telegram API error: %s", e)
+


### PR DESCRIPTION
## Summary
- Send formatted DM to OWNER_ID on successful purchases
- Ping OWNER_ID on startup to verify config
- Ensure purchase handler triggers notification

## Testing
- `python -m py_compile bot/utils/notifications.py bot/main.py bot/handlers/user/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5f9d0db848332951e4ed26fe93920